### PR TITLE
Fix macOS build;

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -484,7 +484,7 @@ if (BUILD_SHARED_LIBS)
     set(LJ_DEFINITIONS ${LJ_DEFINITIONS} -DLUA_BUILD_AS_DLL)
   endif()
   if (APPLE)
-    target_link_libraries("-image_base 7fff04c4a000")
+    target_link_libraries(libluajit "-image_base 7fff04c4a000")
   endif()
 endif()
 


### PR DESCRIPTION
Here's a small fix for macOS builds.  Without it, there are error messages like the following:

```
CMake Error at luajit/src/CMakeLists.txt:487 (target_link_libraries):
  Cannot specify link libraries for target "-image_base 7fff04c4a000" which
  is not built by this project.
```

Thank you for maintaining this fork!